### PR TITLE
Update to cl-lib

### DIFF
--- a/dropbox.el
+++ b/dropbox.el
@@ -180,7 +180,7 @@ string: \"%\" followed by two lowercase hex digits."
         (cl-loop for ent across (cdr (assoc 'contents value))
               for path = (concat dropbox-prefix
                                  (string-strip-prefix "/" (cdr (assoc 'path ent))))
-              cl-do (dropbox-cache "metadata" path ent)))
+              do (dropbox-cache "metadata" path ent)))
 
     value))
 
@@ -775,13 +775,13 @@ NOSORT is useful if you plan to sort the result yourself."
       (cl-loop for file in (if wildcard
                             (directory-files (file-name-directory filename) t filename)
                           (directory-files filename t))
-            cl-do (insert-directory file switches)))))
+            do (insert-directory file switches)))))
 
 (defun dropbox-handle-dired-insert-directory (dir switches &optional file-list
                                                   wildcard hdr)
   (if file-list
       (cl-loop for file in file-list
-            cl-do (dropbox-handle-insert-directory (concat dir file) switches))
+            do (dropbox-handle-insert-directory (concat dir file) switches))
     (dropbox-handle-insert-directory dir switches wildcard t)))
 
 (defun dropbox-handle-copy-file (file newname &optional ok-if-already-exists

--- a/dropbox.el
+++ b/dropbox.el
@@ -49,6 +49,7 @@
 
 (require 'oauth)
 (require 'json)
+(require 'cl-lib)
 
 ;;; Customization Options
 

--- a/dropbox.el
+++ b/dropbox.el
@@ -176,15 +176,15 @@ string: \"%\" followed by two lowercase hex digits."
     (if (and (string= name "metadata")
              (not (dropbox-error-p value))
              (assoc 'contents value))
-        (loop for ent across (cdr (assoc 'contents value))
+        (cl-loop for ent across (cdr (assoc 'contents value))
               for path = (concat dropbox-prefix
                                  (string-strip-prefix "/" (cdr (assoc 'path ent))))
-              do (dropbox-cache "metadata" path ent)))
+              cl-do (dropbox-cache "metadata" path ent)))
 
     value))
 
 (defun dropbox-un-cache (name path)
-  (setf dropbox-cache (remove-if '(lambda (x) (equal (car x) (cons name path)))
+  (setf dropbox-cache (cl-remove-if '(lambda (x) (equal (car x) (cons name path)))
                                  dropbox-cache)))
 
 (defun dropbox-uncache ()
@@ -276,7 +276,7 @@ non-nil."
       (let ((code (dropbox-get-http-code buf)))
         (if (dropbox-http-down-p code)
             (error "Dropbox seems to be having problems: %d %s"
-                   (cadr code) (caddr code))))
+                   (cadr code) (cl-caddr code))))
       (beginning-of-line)
       (let ((json-false nil))
         (json-read)))))
@@ -553,7 +553,7 @@ FILENAME names a directory"
 
   (if (and connected (not dropbox-access-token))
       nil
-    (case identification
+    (cl-case identification
       ((method) dropbox-prefix)
       ((user) "")
       ((host) "")
@@ -650,7 +650,7 @@ NOSORT is useful if you plan to sort the result yourself."
 	 (metadata (dropbox-get-json "metadata" directory t)) ; want-contents: t
 	 (unsorted
 	  (if (cdr (assoc 'is_dir metadata))
-	      (loop for file across (cdr (assoc 'contents metadata))
+	      (cl-loop for file across (cdr (assoc 'contents metadata))
 		    for fname = (dropbox-extract-fname file path full)
 		    if (or (null match) (string-match match fname))
 		    collect fname)
@@ -662,7 +662,7 @@ NOSORT is useful if you plan to sort the result yourself."
     (list*
      (cons "." (file-attributes directory))
      (cons ".." (file-attributes (dropbox-parent directory)))
-     (loop for file in files
+     (cl-loop for file in files
            for attrs = (file-attributes (concat (file-name-as-directory directory)
                                                 file) id-format)
            collect (cons file attrs)))))
@@ -771,16 +771,16 @@ NOSORT is useful if you plan to sort the result yourself."
                             (+ shared normal) (- total normal shared)
                             (/ (* (+ shared normal) 100.0) total))))
             (newline))))
-      (loop for file in (if wildcard
+      (cl-loop for file in (if wildcard
                             (directory-files (file-name-directory filename) t filename)
                           (directory-files filename t))
-            do (insert-directory file switches)))))
+            cl-do (insert-directory file switches)))))
 
 (defun dropbox-handle-dired-insert-directory (dir switches &optional file-list
                                                   wildcard hdr)
   (if file-list
-      (loop for file in file-list
-            do (dropbox-handle-insert-directory (concat dir file) switches))
+      (cl-loop for file in file-list
+            cl-do (dropbox-handle-insert-directory (concat dir file) switches))
     (dropbox-handle-insert-directory dir switches wildcard t)))
 
 (defun dropbox-handle-copy-file (file newname &optional ok-if-already-exists
@@ -957,7 +957,7 @@ The optional seventh arg MUSTBENEW, if non-nil, insists on a check
   if the user confirms."
 
   ; TODO: implement lockname and mustbenew
-  (assert (not append)) ; TODO: implement append
+  (cl-assert (not append)) ; TODO: implement append
 
   (let ((localfile (make-auto-save-file-name)))
     (write-region start end localfile nil 1)


### PR DESCRIPTION
Seeing as how `cl-lib` seems to be the new `cl`, and I don't want to overwrite some built-in Emacs Lisp functions with Common Lisp functions, I took it upon myself to change all old `cl` function calls within `dropbox.el` to use the new `cl-` prefix.

Hopefully I caught all instances. I used [this method](https://yoo2080.wordpress.com/2013/08/12/highlighting-old-style-cl-function-names-in-emacs-lisp/) to highlight all old-style `cl` functions.

Using `cl-lib` ensures compatibility with everyone's Emacs configuration. The old `cl` library would overwrite Elisp functions, potentially used in somebody's `init.el` and break it.

I haven't tested the package thoroughly, but opening and saving a Dropbox file has been working well.