### PR TITLE
Switch to APIv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,35 +3,44 @@
 `dropbox.el`, A Dropbox Client for Emacs
 ========================================
 
-It's often joked that Emacs is an operating system; well, it might as well have a Dropbox client.
+If Emacs is an operating system it should have a Dropbox client.
 
-`dropbox.el` provides a partial Dropbox client for Emacs.  You can log in to Dropbox and read and write your files.  Since it implements handlers for all of the normal Emacs file operations, `dropbox.el` can also be considered a Dropbox API client in Emacs Lisp.
+`dropbox.el` provides lets your read and write Dropbox files from
+Emacs.
 
-`dropbox.el` is available in the [Marmalade](https://marmalade-repo.org) repository, under the name "`dropbox`".
+`dropbox.el` is available in [Marmalade](https://marmalade-repo.org)
+under the name `dropbox`.
 
 Setting Up
 ----------
 
-The first step is to get `dropbox.el`; the easiest way is to use the Marmalade repository, but you can also just download the `dropbox.el` file from this very project.  However, *before you use it*, you'll need to set up a few configuration variables.  `customize-group`, with group `dropbox`, will take you to a configuration screen.
+After downloading `dropbox.el`, you'll need to authorize it to connect
+to your Dropbox. Run `customize-group`, with group `dropbox`; you
+should see a field for your Dropbox "access token".
 
-The key step is to set up the "Consumer Key" and "Consumer Secret" variables. Unfortunately, Dropbox uses OAuth 1.0, which isn't particularly friendly to open source applications since it requires keeping a key secret.  Instead, you'll have to create your own, private application key and secret, and tell `dropbox.el` to use these.
+To create this token, navigate to the [Dropbox developers
+console](https://www.dropbox.com/developers/apps/create) and click
+through the questions to create a new Dropbox app. (Choose the
+"Dropbox API" option and give it access to the full Dropbox.)
 
-To do this, navigate over to the [Dropbox developers console](https://www.dropbox.com/developers/apps/create).  You'll want to create an application for the "Core" API.  Any name at all works for the application name, and you want to give it access to your full Dropbox.
-
-Click "Create App", and you'll be taken to a page that includes the "App key" and "App secret".  You'll want to enter these into the corresponding fields in the Customize window, and save the buffer.  You are, of course, free to ignore Customize and just stick the necessary settings into your `init.el` instead.
-
-Once you have a consumer key and secret set up (and don't worry, you only need to do this once), you can run `dropbox-connect` to get a special token from Dropbox and begin using the API.  The token is stored, by default, in `~/.emacs.d/dropbox-token`, but you can change this with the `dropbox-token-file` variable.  `dropbox-connect` will cause you to browse to a web page asking you to allow the application to use your Dropbox; allow it to, and you're done.
+Click "Create App", and you'll be taken to the new app's details page. Find the text "Generate Access Token" and click the "Generate" button below it. Copy and paste the long random string you get in response into the "access token" field in Emacs. Save the buffer, and you're ready to use Dropbox.
 
 Using `dropbox.el`
 ------------------
 
-Once connected, you can use `dropbox.el` by simply attempting to open a file in any folder beginning with `/db:`.  In particular, if you browse to `/db:`, you'll get a Dired window open onto the root of your Dropbox folder.  You can use many of the usual Dired commands from here; you can also open files and read and write them.
+Once you have saved your access token, you can use `dropbox.el` by
+simply attempting to open a file in any folder beginning with `/db:`.
+
+For example, if you open the path `/db:`, you'll get a Dired window in
+the root of your Dropbox folder. You can use many of the usual Dired
+commands from here; you can also open files to edit them.
 
 Unsupported
 -----------
 
 `dropbox.el` supports much of the functionality you'd expect from an Emacs Dropbox client.  A few otherwise-reasonable features aren't yet supported.
 
+ + Some file operations are still in progress, in particular file and directory copy and rename
  + None of the `shell-command` or `process-file` variants are supported, though it might be possible to implement them by downloading local copies.
  + Not all optional arguments are implemented for many function, though the most commonly-used functionality is there.
  + Image files seem to have strange problems.


### PR DESCRIPTION
Merges @maxsatula's port to v2 of the Dropbox API, along with a README update describing the new setup flow. The main unimplemented bits are file copy and rename, and several annoying bugs (like the error message for unknown files.

There also seems to be a bad interaction with helm. I'm not sure why, but it's worth looking into and fixing.